### PR TITLE
chore: modernize ci emacs version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          # - '23.4'
-          # - '24.1'
-          # - '24.5'
           - '25.1'
-          - '25.3'
-          - '26.1'
-          - '26.2'
           - '26.3'
-          - '27.1'
+          - '27.2'
+          - '28.2'
+          - '29.4'
+          - '30.2'
           - 'snapshot'
         include:
           - emacs_version: 'snapshot'


### PR DESCRIPTION
## Summary

Modernizes the project's dependency surface.

### Package dependencies — already current
- `ov` is pinned at `1.0.6` in `Package-Requires`, which is the latest upstream release of `emacsorphanage/ov`. No bump available.
- `buttercup` (dev dependency in `Cask`) is unpinned, so Cask already resolves the latest release on every install.
- Cask has no lockfile (`.cask` is gitignored), so there is nothing to regenerate.

### GitHub Actions — already at latest majors
- `actions/checkout@v6` and `actions/setup-python@v6` are already on the latest major versions.
- `purcell/setup-emacs@master` and `conao3/setup-cask@master` track `master`, i.e. always latest.

### CI Emacs matrix — modernized (this change)
The only outdated dependency surface was the CI Emacs version matrix, which topped out at the 2020-era Emacs 27.1. Updated to cover the supported range from the declared minimum up to the current stable release:

- Before: `25.1, 25.3, 26.1, 26.2, 26.3, 27.1, snapshot`
- After: `25.1, 26.3, 27.2, 28.2, 29.4, 30.2, snapshot`

`25.1` is kept as the floor since it is the minimum declared in `Package-Requires`. Commented-out dead entries (23.4 / 24.1 / 24.5) were removed.

### Deferred major upgrades
None. The package's own dependencies (`ov`, `buttercup`) are already at their latest versions, so no major bump was needed or deferred. The minimum Emacs requirement (`emacs "25.1"`) was intentionally left unchanged — raising it would drop support for older Emacs rather than update a dependency to a newer release.

## Test plan
- [ ] `make test` passes across the new Emacs matrix in CI (25.1 → 30.2)

https://claude.ai/code/session_01XxLCYSsSJsMCocTQeUkhRx

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxLCYSsSJsMCocTQeUkhRx)_